### PR TITLE
feat: enable use of content of any deployed pointer

### DIFF
--- a/src/utils/content/index.ts
+++ b/src/utils/content/index.ts
@@ -9,6 +9,7 @@ export type ContentData = {
   contentDeclaration: string
 }
 let cachedData: ContentData | null = null
+let entityPointerCachedData: ContentData | null = null
 
 export async function getGenesisPlazaContent(): Promise<ContentData | undefined> {
   const contentUrl = 'https://peer.decentraland.org/content'
@@ -28,5 +29,29 @@ export async function getGenesisPlazaContent(): Promise<ContentData | undefined>
       contentDeclaration
     }
     return cachedData
+  } catch (err) {}
+}
+
+export async function getEntityPointerContentMappings(): Promise<ContentData | undefined> {
+  const contentUrl = 'https://peer.decentraland.org/content'
+  if (entityPointerCachedData) {
+    return entityPointerCachedData
+  }
+  try {
+    const qs = new URLSearchParams(document.location.search)
+
+    if (!qs.has('entity_pointer')) return
+
+    const pointer = qs.get('entity_pointer')
+    const pointerUrl = `${contentUrl}/entities/${pointer}`
+    const pointerUrlResponse = ((await (await fetch(pointerUrl)).json()) as any)[0]
+    const content = pointerUrlResponse.content as ContentMapping[]
+
+    entityPointerCachedData = {
+      baseUrl: `${contentUrl}/contents/`,
+      content,
+      contentDeclaration: ''
+    }
+    return entityPointerCachedData
   } catch (err) {}
 }


### PR DESCRIPTION
adds `entity_pointer` query param to fetch content from any deployed pointer.
i.e `entity_pointer=scene?pointer=-149,-144`, `entity_pointer=emote?pointer=urn:decentraland:matic:collections-v2:0xd3db80bd1f71d064ef97313e67b0e7d64b15cc40:0`, etc